### PR TITLE
fix #76 added function as data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ In order to use the results from spike-records, you must pass it an object, whic
 
 I know this is an unusual pattern for a javascript library, but the way it works is quite effective in this particular system, and affords a lot of flexibility and power.
 
-The records plugin accepts an object, and each key in the object (other than `addDataTo`) should contain another object as it's value, with either a `file`, `url`, or `data` property. For example:
+The records plugin accepts an object, and each key in the object (other than `addDataTo`) should contain another object as it's value, with either a `file`, `url`, `data`, `graphql` or `callback` property. For example:
 
 ```js
 const Records = require('spike-records')
 const locals = {}
+function myFunc () {
+  // call any arbitrary API or computation to produce data
+  return new Promise((resolve, reject) => {...}
+}
 
 module.exports = {
   plugins: [new Records({
@@ -62,7 +66,8 @@ module.exports = {
         variables: 'xxx', // optional
         headers: { authorization: 'Bearer xxx' } // optional
       }
-    }
+    },
+    five: { callback: myFunc }
   })]
 }
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,7 @@ function run (compiler, compilation, done) {
   // place all resolved data and promised into a "tasks" object with their
   // appropriate keys. Promises still need to be resolved at this point.
   for (const k in this.opts) {
+    if (this.opts[k].callback) { tasks[k] = this.opts[k].callback() }
     if (this.opts[k].data) { tasks[k] = renderData(this.opts[k]) }
     if (this.opts[k].url) { tasks[k] = renderUrl(this.opts[k]) }
     if (this.opts[k].graphql) { tasks[k] = renderGraphql(this.opts[k]) }

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,26 @@ const htmlStandards = require('reshape-standard')
 
 const fixturesPath = path.join(__dirname, 'fixtures')
 
+
+test('loads callback correctly', t => {
+  const locals = {}
+  function myFunc () {
+    return new Promise((resolve, reject) => {
+      return resolve ({success: 'true'})
+    })
+  }
+
+  return compileAndCheck({
+    fixture: 'data',
+    locals,
+    config: { addDataTo: locals, test: { callback: myFunc } },
+    verify: (_, publicPath) => {
+      const out = fs.readFileSync(path.join(publicPath, 'index.html'), 'utf8')
+      t.is(out.trim(), '<p>true</p>')
+    }
+  })
+})
+
 test('loads data correctly', t => {
   const locals = {}
   return compileAndCheck({


### PR DESCRIPTION
I sneaked in an additional fix that's not completely related to the fix. 
In the README.md: Added `graphql` in the usage verbiage.