### PR TITLE
Update reshape to version 1.0.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "bugs": "https://github.com/static-dev/spike-records/issues",
   "dependencies": {
     "es6bindall": "^0.0.9",
-    "reshape": "^0.5.0",
-    "reshape-loader": "^1.1.0",
+    "reshape": "^1.0.0",
+    "reshape-loader": "^1.3.0",
     "rest": "^2.0.0",
     "spike-util": "^1.3.0",
     "when": "^3.7.7"


### PR DESCRIPTION
It seems that gatekeeper missed the 0.5.1 and 1.0.0 versions.

I only recently started using Spike and so all versions are the most recent, but when I tried compiling the site, it would throw the following:

```
✗ ERROR
{ Error: Unrecognized node type: doctype
Node: {"type":"doctype","content":"<!DOCTYPE html>","location":{"line":1,"col":13}}

    at tree.reduce (/path/to/project/node_modules/reshape-code-gen/lib/index.js:95:11)
```

I had been comparing it to a working clone of `spike-graphcms-netlify-example`, but I noticed the reshape versions were significantly different and that `sugarml` was missing from the newer versions. I had attempted to use the `master` branch from this repo, but to no avail. After forking the repo and updating these two dependency versions, my site compiled as designed.