### PR TITLE
Add options for renderUrl

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -108,7 +108,13 @@ function renderFile (root, obj) {
 }
 
 function renderUrl (obj) {
-  return rest(obj.url).then((res) => { return JSON.parse(transformRaw(obj, res.entity)) })
+  const headers = Object.assign({'Content-Type':'application/json'}, obj.headers);
+  return rest({
+    path: obj.url,
+    method: obj.method,
+    entity: JSON.stringify(obj.entity),
+    headers
+  }).then((res) => { return JSON.parse(transformRaw(obj, res.entity)) })
 }
 
 function renderGraphql (obj) {


### PR DESCRIPTION
By default, passing options to an endpoint is only available in the renderGraphql function with spike-records. Cockpit CMS requires posting an entity to an endpoint in order to filter results so I needed the ability to change the METHOD and send along a payload. I didn't do much other than copy the code from the renderGraphql function, but this allows a user to perform more than just GET requests with renderUrl